### PR TITLE
Fix Vault-save QuickBeltArea.cs

### DIFF
--- a/OpenScripts2/src/CustomQuickBeltSlots/QuickBeltArea.cs
+++ b/OpenScripts2/src/CustomQuickBeltSlots/QuickBeltArea.cs
@@ -120,6 +120,9 @@ namespace OpenScripts2
                 {
                     MainObject.RegisterQuickbeltSlots();
                 }
+                foreach (FVRQuickBeltSlot mainObjSlot in MainObject.Slots) {
+                    mainObjSlot.SetAffixedTo(MainObject);
+                }
             }
             else
             {


### PR DESCRIPTION
Sets the m_affixedTo value of each QBSlot to the main backpack, curretly this is null, as it is necessary to pass the IsDeepBelted() check in the FindAndScanObjectsInQuickbelt.

Verified it works by manually setting m_affixedTo in UnityExplorer, with the full Quickbelt-vault save/spawn working. Code change itself was not tested since idk how to build your OS2, but this is the root cause fix